### PR TITLE
fix(ci): upgrade deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - run: npm ci
@@ -27,7 +27,7 @@ jobs:
             -cvf "artifact.tar" \
             .
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'github-pages'
           path: artifact.tar
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Upgrade actions/checkout from v3 to v4
- Upgrade actions/setup-node from v3 to v4
- Upgrade actions/upload-artifact from v3 to v4
- Upgrade actions/deploy-pages from v2 to v4